### PR TITLE
Declare a dependency on Emacs 24.4

### DIFF
--- a/focus-autosave-mode.el
+++ b/focus-autosave-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: Wojciech Siewierski <wojciech.siewierski@onet.pl>
 ;; Keywords: convenience, files, frames, mouse
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
`focus-out-hook` was not added until this Emacs version.
